### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,12 @@ codegen-units = 1
 
 [dependencies]
 failure = { version = "^0.1.3", default_features = false, features = ["derive"] }
+serde = { version = "^1.0" , package = "serde", optional = true }
 
 [dev-dependencies]
 regex = "^1.0"
+serde_derive = "^1.0"
+serde_bytes = "^0.11.3"
 
 ### FEATURES ###################################################################
 

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -69,7 +69,7 @@ mod from_bencode;
 mod object;
 
 pub use self::{
-    decoder::{Decoder, DictDecoder, ListDecoder},
+    decoder::{Decoder, DictDecoder, ListDecoder, Tokens},
     error::{Error, ErrorKind, ResultExt},
     from_bencode::FromBencode,
     object::Object,

--- a/src/decoding/from_bencode.rs
+++ b/src/decoding/from_bencode.rs
@@ -57,7 +57,7 @@ macro_rules! impl_from_bencode_for_integer {
     )*}
 }
 
-impl_from_bencode_for_integer!(u8 u16 u32 u64 usize i8 i16 i32 i64 isize);
+impl_from_bencode_for_integer!(u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize);
 
 impl<ContentT: FromBencode> FromBencode for Vec<ContentT> {
     const EXPECTED_RECURSION_DEPTH: usize = ContentT::EXPECTED_RECURSION_DEPTH + 1;

--- a/src/encoding/printable_integer.rs
+++ b/src/encoding/printable_integer.rs
@@ -12,4 +12,4 @@ macro_rules! impl_integer {
     )*}
 }
 
-impl_integer!(u8 u16 u32 u64 usize i8 i16 i32 i64 isize);
+impl_integer!(u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize);

--- a/src/encoding/to_bencode.rs
+++ b/src/encoding/to_bencode.rs
@@ -103,7 +103,7 @@ macro_rules! impl_encodable_integer {
     )*}
 }
 
-impl_encodable_integer!(u8 u16 u32 u64 usize i8 i16 i32 i64 isize);
+impl_encodable_integer!(u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize);
 
 macro_rules! impl_encodable_iterable {
     ($($type:ident)*) => {$(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,6 @@ extern crate alloc;
 pub mod decoding;
 pub mod encoding;
 pub mod state_tracker;
+
+#[cfg(feature = "serde")]
+pub mod serde;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,354 @@
+//! Serde bencode serialization and deserialization.
+//!
+//! The Serde data model contains a number of types which have no native bencode
+//! representation. Serializing and deserializing these types is currently
+//! unsupported:
+//! - `()`
+//! - `HashMap` and `BTreeMap`
+//! - `Option`
+//! - `bool`
+//! - `char`
+//! - `f32` and `f64`
+//! - enums
+//! - unit structs
+//!
+//! In addition, the current implementation is not self-describing, so
+//! deserialization relying on  `serde::de::Deserializer::deserialize_any` is
+//! unsupported.
+
+mod common;
+
+pub mod de;
+pub mod error;
+pub mod ser;
+
+pub use de::{from_bytes, Deserializer};
+pub use error::Error;
+pub use error::Result;
+pub use ser::{to_bytes, Serializer};
+
+#[cfg(test)]
+mod tests {
+    use super::common::*;
+
+    use serde::{de::DeserializeOwned, ser::Serialize};
+    use serde_derive::{Deserialize, Serialize};
+
+    use super::{de::from_bytes, ser::to_bytes};
+
+    fn case<V, B>(value: V, want: B)
+    where
+        V: Serialize + DeserializeOwned + PartialEq + Debug,
+        B: AsRef<[u8]>,
+    {
+        let want = want.as_ref();
+
+        let encoded = match to_bytes(&value) {
+            Ok(have) => {
+                assert_eq!(
+                    have,
+                    want,
+                    "Expected `{}` but got `{}` when serializing `{:?}`",
+                    String::from_utf8_lossy(&want),
+                    String::from_utf8_lossy(&have),
+                    value
+                );
+                have
+            }
+            Err(err) => panic!("Failed to serialize `{:?}`: {}", value, err),
+        };
+
+        let deserialized = match from_bytes::<V>(&encoded) {
+            Ok(deserialized) => deserialized,
+            Err(error) => panic!(
+                "Failed to deserialize `{:?}` from `{}`: {}",
+                value,
+                String::from_utf8_lossy(&encoded),
+                error
+            ),
+        };
+
+        assert_eq!(
+            deserialized, value,
+            "Deserialized value != original: `{:?}` != `{:?}`",
+            deserialized, value
+        );
+    }
+
+    fn case_borrowed<V, B>(value: V, want: B)
+    where
+        V: Serialize + Debug,
+        B: AsRef<[u8]>,
+    {
+        let want = want.as_ref();
+
+        match to_bytes(&value) {
+            Ok(have) => {
+                assert_eq!(
+                    have,
+                    want,
+                    "Expected `{}` but got `{}` when serializing `{:?}`",
+                    String::from_utf8_lossy(&want),
+                    String::from_utf8_lossy(&have),
+                    value
+                );
+            }
+            Err(err) => panic!("Failed to serialize `{:?}`: {}", value, err),
+        }
+    }
+
+    #[test]
+    fn scalar() {
+        case(0u8, "i0e");
+        case(1u8, "i1e");
+        case(0u16, "i0e");
+        case(1u16, "i1e");
+        case(0u32, "i0e");
+        case(1u32, "i1e");
+        case(0u64, "i0e");
+        case(1u64, "i1e");
+        case(0u128, "i0e");
+        case(1u128, "i1e");
+        case(0usize, "i0e");
+        case(1usize, "i1e");
+        case(0i8, "i0e");
+        case(1i8, "i1e");
+        case(-1i8, "i-1e");
+        case(0i16, "i0e");
+        case(1i16, "i1e");
+        case(-1i16, "i-1e");
+        case(0i32, "i0e");
+        case(1i32, "i1e");
+        case(-1i32, "i-1e");
+        case(0i64, "i0e");
+        case(1i64, "i1e");
+        case(-1i64, "i-1e");
+        case(0i128, "i0e");
+        case(1i128, "i1e");
+        case(-1i128, "i-1e");
+        case(0isize, "i0e");
+        case(1isize, "i1e");
+        case(-1isize, "i-1e");
+    }
+
+    #[test]
+    fn str() {
+        case_borrowed("foo", "3:foo");
+    }
+
+    #[test]
+    fn string() {
+        case("foo".to_string(), "3:foo");
+    }
+
+    #[test]
+    fn bytes_default() {
+        let value: Vec<u8> = vec![1, 2, 3, 4];
+        case(value, "li1ei2ei3ei4ee");
+    }
+
+    #[test]
+    fn bytes_with_serde_bytes() {
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        #[serde(transparent)]
+        struct Owned {
+            #[serde(with = "serde_bytes")]
+            bytes: Vec<u8>,
+        }
+
+        case(
+            Owned {
+                bytes: vec![1, 2, 3],
+            },
+            "3:\x01\x02\x03",
+        );
+
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        #[serde(transparent)]
+        struct Borrowed<'bytes> {
+            #[serde(with = "serde_bytes")]
+            bytes: &'bytes [u8],
+        }
+
+        case_borrowed(Borrowed { bytes: &[1, 2, 3] }, b"3:\x01\x02\x03");
+    }
+
+    #[test]
+    fn newtype_struct() {
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        struct Foo(u8);
+        case(Foo(1), "i1e");
+    }
+
+    #[test]
+    fn seq() {
+        case(vec![1, 0, 1], "li1ei0ei1ee");
+    }
+
+    #[test]
+    fn tuple_struct() {
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct Foo(String, u32, i32);
+
+        case(Foo("hello".to_string(), 1, -100), "l5:helloi1ei-100ee");
+    }
+
+    #[test]
+    fn struct_test() {
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct Foo {
+            a: u8,
+            b: String,
+        }
+
+        case(
+            Foo {
+                a: 1,
+                b: "hello".to_string(),
+            },
+            "d1:ai1e1:b5:helloe",
+        );
+    }
+
+    #[test]
+    fn struct_field_order() {
+        // Serde serializes the fields of this struct in the opposite
+        // order to that mandated by bencode. This would trigger an
+        // error if the struct serializer failed to correctly order
+        // the fields during serialization.
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
+        struct Foo {
+            fac: u8,
+            fb: u8,
+        }
+
+        case(Foo { fac: 0, fb: 1 }, "d3:faci0e2:fbi1ee");
+    }
+
+    #[test]
+    #[should_panic(expected = "serialize_bool: not supported")]
+    fn unsupported_bool_serialize() {
+        to_bytes(&true).ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_bool: not supported")]
+    fn unsupported_bool_deserialize() {
+        from_bytes::<bool>(b"").ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_f32: not supported")]
+    fn unsupported_f32_deserialize() {
+        from_bytes::<f32>(b"").ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "serialize_f32: not supported")]
+    fn unsupported_f32_serialize() {
+        to_bytes(&0f32).ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_f64: not supported")]
+    fn unsupported_f64_deserialize() {
+        from_bytes::<f64>(b"").ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "serialize_f64: not supported")]
+    fn unsupported_f64_serialize() {
+        to_bytes(&0f64).ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_option: not supported")]
+    fn unsupported_option_deserialize() {
+        from_bytes::<Option<()>>(b"").ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "serialize_some: not supported")]
+    fn unsupported_some_serialize() {
+        to_bytes(&Some(0)).ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "serialize_none: not supported")]
+    fn unsupported_none_serialize() {
+        to_bytes::<Option<u8>>(&None).ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_unit: not supported")]
+    fn unsupported_unit_deserialize() {
+        from_bytes::<()>(b"").ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "serialize_unit: not supported")]
+    fn unsupported_unit_serialize() {
+        to_bytes(&()).ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_unit_struct: not supported")]
+    fn unsupported_unit_struct_deserialize() {
+        #[derive(Deserialize)]
+        struct Foo;
+        from_bytes::<Foo>(b"").ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "serialize_unit_struct: not supported")]
+    fn unsupported_unit_struct_serialize() {
+        #[derive(Serialize)]
+        struct Foo;
+        to_bytes(&Foo).ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_char: not supported")]
+    fn unsupported_char_deserialize() {
+        from_bytes::<char>(b"").ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "serialize_char: not supported")]
+    fn unsupported_char_serialize() {
+        to_bytes(&'a').ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_map: not supported")]
+    fn unsupported_map_deserialize() {
+        from_bytes::<BTreeMap<u8, u8>>(b"").ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "serialize_map: not supported")]
+    fn unsupported_map_serialize() {
+        let map: BTreeMap<u8, u8> = BTreeMap::new();
+        to_bytes(&map).ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_enum: not supported")]
+    fn unsupported_enum_deserialize() {
+        #[derive(Deserialize)]
+        enum Foo {}
+        from_bytes::<Foo>(b"").ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "deserialize_any: not supported")]
+    fn unsupported_any_deserialize() {
+        #[serde(untagged)]
+        #[derive(Deserialize)]
+        pub(crate) enum Foo {
+            A { _x: char },
+            B { _x: String },
+        }
+        from_bytes::<Foo>(b"").ok();
+    }
+}

--- a/src/serde/common.rs
+++ b/src/serde/common.rs
@@ -1,0 +1,26 @@
+/// Standard library
+pub(crate) use std::{
+    collections::BTreeMap,
+    fmt::{self, Debug, Display, Formatter},
+    iter::Peekable,
+    num::ParseIntError,
+    str::{self, Utf8Error},
+};
+
+/// Dependencies
+pub(crate) use serde::{
+    de::{DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor},
+    ser::{
+        Serialize, SerializeMap, SerializeSeq, SerializeStructVariant, SerializeTuple,
+        SerializeTupleStruct, SerializeTupleVariant,
+    },
+    Deserialize,
+};
+
+/// Structs and enums
+pub(crate) use crate::{
+    decoding::{self, Decoder, Tokens},
+    encoding::{self, Encoder},
+    serde::{ser::Serializer, Error, Result},
+    state_tracker::{StructureError, Token},
+};

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,0 +1,413 @@
+//! Serde bencode deserialization.
+
+use crate::serde::common::*;
+
+/// Deserialize an instance of `T` from bencode
+pub fn from_bytes<'a, T>(s: &'a [u8]) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    Deserializer::from_bytes(s).deserialize()
+}
+
+/// Bencode deserializer
+pub struct Deserializer<'de> {
+    tokens: Peekable<Tokens<'de>>,
+}
+
+impl<'de> Deserializer<'de> {
+    /// Create a new `Deserializer` with the give byte slice
+    pub fn from_bytes(input: &'de [u8]) -> Self {
+        Deserializer {
+            tokens: Decoder::new(input).tokens().peekable(),
+        }
+    }
+
+    /// Consume the deserializer, producing an instance of `T`
+    pub fn deserialize<T>(mut self) -> Result<T, Error>
+    where
+        T: Deserialize<'de>,
+    {
+        T::deserialize(&mut self)
+    }
+}
+
+impl<'de> Deserializer<'de> {
+    fn next_token(&mut self) -> Result<Token<'de>> {
+        match self.tokens.next() {
+            Some(result) => Ok(result?),
+            None => Err(Error::Decode(StructureError::UnexpectedEof.into())),
+        }
+    }
+
+    fn next_integer(&mut self) -> Result<&'de str> {
+        match self.next_token()? {
+            Token::Num(num) => Ok(num),
+            other => Err(decoding::Error::unexpected_token("Num", other.name()).into()),
+        }
+    }
+
+    fn next_bytes(&mut self) -> Result<&'de [u8]> {
+        match self.next_token()? {
+            Token::String(bytes) => Ok(bytes),
+            other => Err(decoding::Error::unexpected_token("String", other.name()).into()),
+        }
+    }
+
+    fn next_string(&mut self) -> Result<&'de str> {
+        let bytes = self.next_bytes()?;
+        let string = str::from_utf8(bytes)?;
+        Ok(string)
+    }
+
+    fn expect_list_begin(&mut self) -> Result<()> {
+        match self.next_token()? {
+            Token::List => Ok(()),
+            other => Err(decoding::Error::unexpected_token("List", other.name()).into()),
+        }
+    }
+
+    fn expect_dict_begin(&mut self) -> Result<()> {
+        match self.next_token()? {
+            Token::Dict => Ok(()),
+            other => Err(decoding::Error::unexpected_token("Dict", other.name()).into()),
+        }
+    }
+
+    fn expect_end(&mut self) -> Result<()> {
+        match self.next_token()? {
+            Token::End => Ok(()),
+            other => Err(decoding::Error::unexpected_token("End", other.name()).into()),
+        }
+    }
+
+    fn peek_end(&mut self) -> bool {
+        self.peek() == Some(Token::End)
+    }
+
+    fn peek(&mut self) -> Option<Token<'de>> {
+        if let Some(Ok(token)) = self.tokens.peek() {
+            Some(*token)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserialializer::deserialize_any: not supported");
+    }
+
+    fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_bool: not supported");
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i8(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i16(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i32(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i64(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_i128(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u8(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u16(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u32(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u64(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u128(self.next_integer()?.parse()?)
+    }
+
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_f32: not supported");
+    }
+
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_f64: not supported");
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_char: not supported");
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.next_string()?)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_bytes(self.next_bytes()?)
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_option: not supported");
+    }
+
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_unit: not supported");
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_unit_struct: not supported");
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.expect_list_begin()?;
+        let value = visitor.visit_seq(&mut *self)?;
+        self.expect_end()?;
+        Ok(value)
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_map: not supported");
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.expect_dict_begin()?;
+        let value = visitor.visit_map(&mut *self)?;
+        self.expect_end()?;
+        Ok(value)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_enum: not supported");
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        panic!("bendy::Deserializer::deserialize_ignored_any: not supported");
+    }
+}
+
+impl<'de> SeqAccess<'de> for Deserializer<'de> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.peek_end() {
+            return Ok(None);
+        }
+        seed.deserialize(self).map(Some)
+    }
+}
+
+impl<'de> MapAccess<'de> for Deserializer<'de> {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        if self.peek_end() {
+            return Ok(None);
+        }
+        seed.deserialize(self).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self)
+    }
+}
+
+impl<'de> EnumAccess<'de> for &mut Deserializer<'de> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, _seed: V) -> Result<(V::Value, Self)>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        unreachable!()
+    }
+}
+
+impl<'de> VariantAccess<'de> for &mut Deserializer<'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        unreachable!()
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        unreachable!()
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unreachable!()
+    }
+
+    fn struct_variant<V>(self, _fields: &'static [&'static str], _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        unreachable!()
+    }
+}

--- a/src/serde/error.rs
+++ b/src/serde/error.rs
@@ -1,0 +1,70 @@
+///! Serde error and result types
+use crate::serde::common::*;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// An enumeration of potential errors that appear during serde serialiation and
+/// deserialization
+#[derive(Debug)]
+pub enum Error {
+    /// Error that occurs if a serde-related error occurs during serialization
+    CustomEncode(String),
+    /// Error that occurs if a serde-related error occurs during deserialization
+    CustomDecode(String),
+    /// Error that occurs if a problem is encountered during serialization
+    Encode(encoding::Error),
+    /// Error that occurs if a problem is encountered during deserialization
+    Decode(decoding::Error),
+}
+
+impl From<encoding::Error> for Error {
+    fn from(encoding_error: encoding::Error) -> Self {
+        Self::Encode(encoding_error)
+    }
+}
+
+impl From<decoding::Error> for Error {
+    fn from(decoding_error: decoding::Error) -> Self {
+        Self::Decode(decoding_error)
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(parse_int_error: ParseIntError) -> Self {
+        Self::Decode(parse_int_error.into())
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(utf8_error: Utf8Error) -> Self {
+        Self::Decode(utf8_error.into())
+    }
+}
+
+impl serde::ser::Error for Error {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self::CustomEncode(msg.to_string())
+    }
+}
+
+impl serde::de::Error for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        Self::CustomDecode(msg.to_string())
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::CustomEncode(message) => write!(f, "Serialization failed: {}", message),
+            Self::CustomDecode(message) => write!(f, "Deserialization failed: {}", message),
+            Self::Encode(error) => write!(f, "{}", error),
+            Self::Decode(error) => write!(f, "{}", error),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -1,0 +1,349 @@
+//! Serde bencode serialization.
+
+use crate::serde::common::*;
+
+mod struct_serializer;
+
+pub use struct_serializer::StructSerializer;
+
+/// Serialize an instance of `T` to bencode
+pub fn to_bytes<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: ?Sized + Serialize,
+{
+    let mut serializer = Serializer::new();
+    value.serialize(&mut serializer)?;
+    serializer.into_bytes()
+}
+
+/// A serde Bencode serializer
+pub struct Serializer {
+    encoder: Encoder,
+}
+
+impl Serializer {
+    /// Create a new `Serializer`
+    pub fn new() -> Self {
+        Serializer {
+            encoder: Encoder::new(),
+        }
+    }
+
+    /// Create a new `Serializer` with a given maximum serialization depth
+    pub fn with_max_depth(max_depth: usize) -> Serializer {
+        Serializer {
+            encoder: Encoder::new().with_max_depth(max_depth),
+        }
+    }
+
+    /// Consume this `Serializer`, returning the encoded bencode
+    pub fn into_bytes(self) -> Result<Vec<u8>> {
+        Ok(self.encoder.get_output()?)
+    }
+
+    fn struct_serializer(&mut self) -> StructSerializer {
+        let remaining_depth = self.encoder.remaining_depth();
+        StructSerializer::new(self, remaining_depth)
+    }
+
+    pub(crate) fn emit_struct(&mut self, contents: BTreeMap<&'static str, Vec<u8>>) -> Result<()> {
+        self.encoder.emit_token(Token::Dict)?;
+        for (key, value) in contents {
+            self.encoder.emit_bytes(key.as_bytes())?;
+            for result in Decoder::new(&value).tokens() {
+                let token = result?;
+                self.encoder.emit_token(token)?;
+            }
+        }
+        self.encoder.emit_token(Token::End)?;
+        Ok(())
+    }
+}
+
+impl<'a> serde::ser::Serializer for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+    type SerializeMap = Self;
+    type SerializeSeq = Self;
+    type SerializeStruct = StructSerializer<'a>;
+    type SerializeStructVariant = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+
+    fn serialize_bool(self, _v: bool) -> Result<()> {
+        panic!("bendy::Serializer::serialize_bool: not supported");
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_i128(self, v: i128) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<()> {
+        self.encoder.emit(v)?;
+        Ok(())
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<()> {
+        panic!("bendy::Serializer::serialize_f32: not supported");
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<()> {
+        panic!("bendy::Serializer::serialize_f64: not supported");
+    }
+
+    fn serialize_char(self, _v: char) -> Result<()> {
+        panic!("bendy::Serializer::serialize_char: not supported");
+    }
+
+    fn serialize_str(self, v: &str) -> Result<()> {
+        self.serialize_bytes(v.as_bytes())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<()> {
+        self.encoder.emit_bytes(v)?;
+        Ok(())
+    }
+
+    fn serialize_none(self) -> Result<()> {
+        panic!("bendy::Serializer::serialize_none: not supported");
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        panic!("bendy::Serializer::serialize_some: not supported");
+    }
+
+    fn serialize_unit(self) -> Result<()> {
+        panic!("bendy::Serializer::serialize_unit: not supported");
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<()> {
+        panic!("bendy::Serializer::serialize_unit_struct: not supported");
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<()> {
+        panic!("bendy::Serializer::serialize_unit_variant: not supported");
+    }
+
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        panic!("bendy::Serializer::serialize_newtype_variant: not supported");
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        self.encoder.emit_token(Token::List)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        self.encoder.emit_token(Token::List)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        self.encoder.emit_token(Token::List)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        panic!("bendy::Serializer::serialize_tuple_variant: not supported");
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        panic!("bendy::Serializer::serialize_map: not supported");
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(self.struct_serializer())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        panic!("bendy::Serializer::serialize_struct_variant: not supported");
+    }
+}
+
+impl<'a> SerializeSeq for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        self.encoder.emit_token(Token::End)?;
+        Ok(())
+    }
+}
+
+impl<'a> SerializeTuple for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        self.encoder.emit_token(Token::End)?;
+        Ok(())
+    }
+}
+
+impl<'a> SerializeTupleStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        self.encoder.emit_token(Token::End)?;
+        Ok(())
+    }
+}
+
+impl<'a> SerializeMap for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, _key: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        unreachable!()
+    }
+
+    fn serialize_value<T>(&mut self, _value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        unreachable!()
+    }
+
+    fn end(self) -> Result<()> {
+        unreachable!()
+    }
+}
+
+impl<'a> SerializeTupleVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, _value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        unreachable!()
+    }
+
+    fn end(self) -> Result<()> {
+        unreachable!()
+    }
+}
+
+impl<'a> SerializeStructVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, _value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        unreachable!()
+    }
+
+    fn end(self) -> Result<()> {
+        unreachable!()
+    }
+}

--- a/src/serde/ser/struct_serializer.rs
+++ b/src/serde/ser/struct_serializer.rs
@@ -1,0 +1,48 @@
+use crate::serde::common::*;
+
+use serde::ser::SerializeStruct;
+
+/// Bencode sub-serializer for structs.
+pub struct StructSerializer<'outer> {
+    pub(crate) outer: &'outer mut Serializer,
+    contents: BTreeMap<&'static str, Vec<u8>>,
+    remaining_depth: usize,
+}
+
+impl<'outer> StructSerializer<'outer> {
+    pub(crate) fn new(
+        outer: &'outer mut Serializer,
+        remaining_depth: usize,
+    ) -> StructSerializer<'outer> {
+        StructSerializer {
+            contents: BTreeMap::new(),
+            remaining_depth,
+            outer,
+        }
+    }
+}
+
+impl<'outer> SerializeStruct for StructSerializer<'outer> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if self.contents.contains_key(key) {
+            panic!("bendy::StructSerializer::serialize_field: serialize_field called with duplicate field name")
+        }
+
+        let mut serializer = Serializer::with_max_depth(self.remaining_depth);
+        value.serialize(&mut serializer)?;
+        let value_bytes = serializer.into_bytes()?;
+
+        self.contents.insert(key, value_bytes);
+        Ok(())
+    }
+
+    fn end(self) -> Result<()> {
+        self.outer.emit_struct(self.contents)
+    }
+}


### PR DESCRIPTION
Add support for serializing and deserializating values to and from
bencode with serde.

In order to keep the initial implementation simple, only types in the
serde data model which have native or obvious representations in bencode
are supported.